### PR TITLE
Package auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ composer require unisharp/laravel-ckeditor
 
 ### Add ServiceProvider
 
-Edit config/app.php, add the following file to `Application Service Providers` section.
+For Laravel 5.5+ you can skip this step. 
+
+For Laravel 5.4 and earlier edit config/app.php, add the following file to `Application Service Providers` section.
 ```
 Unisharp\Ckeditor\ServiceProvider::class,
 ```

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,12 @@
 	"require": {
 		"illuminate/support": "~5.0"
 	},
-	"minimum-stability": "dev"
+	"minimum-stability": "dev",
+	"extra": {
+		"laravel": {
+			"providers": [
+				"Unisharp\\Ckeditor\\ServiceProvider"
+			]
+		}
+	}
 }


### PR DESCRIPTION
Added package auto discovery which is available in Laravel 5.5+.

After running command:
`composer require unisharp/laravel-ckeditor`

Laravel 5.5+ will look at the composer.json extra field where service provider path is located.

Also updated readme.md